### PR TITLE
some tweaks

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/undetermined-items/blueshield-undetermined.ftl
+++ b/Resources/Locale/en-US/_Goobstation/undetermined-items/blueshield-undetermined.ftl
@@ -13,8 +13,8 @@ blueshield-box-category-cqc-description =
 blueshield-box-category-revolver-name = revolver set
 blueshield-box-category-revolver-description =
     Running out of ammo is the worst thing that could happen in a firefight.
-    Includes: The EG-4 energy revolver, capable of regenerating ammo
-    and firing disabling rounds.
+    Includes: The EG-4 energy revolver, capable of firing using
+    various self-recharging energy speedloaders, both lethal and not.
 
 blueshield-box-category-blueshield-name = blueshield set
 blueshield-box-category-blueshield-description =

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
@@ -30,7 +30,7 @@
     - id: ClothingHeadHelmetSwat
     - id: Flash
     - id: FlashlightSeclite
-    - id: ClothingBlueshieldArmourVest
+    - id: ClothingBeltSecurityFilled
     - id: ClothingOuterHardsuitBlueshield
     - id: BoxZiptie
     - id: OxygenTankFilled

--- a/Resources/Prototypes/_Goobstation/Catalog/undetermined_item_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/undetermined_item_sets.yml
@@ -6,23 +6,23 @@
     sprite: _Goobstation/Objects/Weapons/Guns/Lever/chester.rsi
     state: base
   content:
+  - MagazineShotgunLeverRifleEmpty
+  - MagazineShotgunLeverRifleEmpty
   - MagazineBoxShotgunHighCaliber
   - MagazineBoxShotgunHighCaliberFlash
   - MagazineBoxShotgunHighCaliberEnsnaring
   - MagazineBoxShotgunHighCaliberEMP
   - WeaponLeverChester
-  - MagazineShotgunLeverRifleEmpty
-  - MagazineShotgunLeverRifleEmpty
 
 - type: thiefBackpackSet
   id: CQCSet
   name: blueshield-box-category-cqc-name
   description: blueshield-box-category-cqc-description
   sprite:
-    sprite: _Goobstation/Objects/Weapons/Guns/Lever/chester.rsi # Todo - Change this
-    state: base
+    sprite: Objects/Misc/bureaucracy.rsi # Todo - Change this
+    state: paper
   content:
-  - MagazineBoxShotgunHighCaliber # Todo - Make this a CQC book
+  - Paper # Todo - Make this a CQC book
 
 - type: thiefBackpackSet
   id: RevolverSet
@@ -32,7 +32,11 @@
     sprite: _Goobstation/Objects/Weapons/Guns/Battery/erevolver.rsi
     state: icon
   content:
-  - WeaponEnergyRevolver
+  - WeaponEnergyRevolver # One lethal speedloader inside.
+  - EnergySpeedloaderLethal
+  - EnergySpeedloaderLethal
+  - EnergySpeedloaderDisabler
+  - EnergySpeedloaderDisabler
 
 - type: thiefBackpackSet
   id: BlueshieldSet
@@ -42,5 +46,5 @@
     sprite: _Goobstation/Objects/Shields/blueshieldshield.rsi
     state: icon-on
   content:
-  - BlueShieldShield
   - BlueshieldMace
+  - BlueShieldShield

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/armour.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/armour.yml
@@ -76,27 +76,15 @@
 
 # Blueshield Armour Vest
 - type: entity
-  parent: [ ClothingOuterBaseMedium, AllowSuitStorageClothing, BaseCentcommContraband ]
+  parent: [ BaseCentcommContraband, ClothingOuterArmorCaptainCarapace ]
   id: ClothingBlueshieldArmourVest
   name: blueshield's security armour
-  description: An armoured vest with the badge of the blueshield
+  description: An armoured vest with the badge of the blueshield.
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/Armor/bso_armour.rsi
   - type: Clothing
     sprite: _Goobstation/Clothing/Armor/bso_armour.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.60
-        Slash: 0.60
-        Piercing: 0.65
-        Heat: 0.70
-  - type: ExplosionResistance
-    damageCoefficient: 0.8
-  - type: ModifyDelayedKnockdown # Goobstation
-    delayDelta: 1
-    knockdownTimeDelta: -1
 
 - type: entity
   parent: ClothingBlueshieldArmourVest

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/energy_speedloaders.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/energy_speedloaders.yml
@@ -32,6 +32,16 @@
   name: energy speedloader (lethal)
   description: A special self-recharging powercell designed for use with the energy revolver. This one contains lethal bolts.
   components:
+  - type: Sprite # Remove when sprites are done so it would be base state, i just think that bright orange practice bullets fit more for now.
+    layers:
+      - state: base
+        map: [ "enum.GunVisualLayers.Base" ]
+      - state: practice-6
+        map: [ "enum.GunVisualLayers.Mag" ]
+  - type: MagazineVisuals # Same as above
+    magState: practice
+    steps: 7
+    zeroVisible: false
   - type: ProjectileBatteryAmmoProvider
     proto: BulletEnergyGunMagnum
     fireCost: 100
@@ -50,8 +60,12 @@
     layers:
       - state: base
         map: [ "enum.GunVisualLayers.Base" ]
-      - state: practice-6 # rename to disabler later
+      - state: uranium-6 # Rename it to disabler when sprites are done
         map: [ "enum.GunVisualLayers.Mag" ]
+  - type: MagazineVisuals
+    magState: uranium # Same as above
+    steps: 7
+    zeroVisible: false
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
     fireCost: 50

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/energy_speedloaders.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/energy_speedloaders.yml
@@ -46,6 +46,12 @@
   name: energy speedloader (disabler)
   description: A special self-recharging powercell designed for use with the energy revolver. This one contains disabler bolts.
   components:
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.GunVisualLayers.Base" ]
+      - state: practice-6 # rename to disabler later
+        map: [ "enum.GunVisualLayers.Mag" ]
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
     fireCost: 50

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -125,7 +125,7 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: null
+        startingItem: EnergySpeedloaderLethal
         insertSound: /Audio/Weapons/Guns/MagIn/revolver_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/revolver_magout.ogg
         whitelist:

--- a/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -30,14 +30,14 @@
 
 # Jumpsuits
 - type: loadout
-  id: BlueshieldOfficerInnerBlueshieldSkirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtBlueshieldOfficer
-
-- type: loadout
   id: BlueshieldOfficerInnerBlueshieldSuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitBlueshieldOfficer
+
+- type: loadout
+  id: BlueshieldOfficerInnerBlueshieldSkirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtBlueshieldOfficer
 
 - type: loadout
   id: BlueshieldOfficerInnerBlueshieldShirt

--- a/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -30,14 +30,14 @@
 
 # Jumpsuits
 - type: loadout
-  id: BlueshieldOfficerInnerBlueshieldSuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitBlueshieldOfficer
-
-- type: loadout
   id: BlueshieldOfficerInnerBlueshieldSkirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtBlueshieldOfficer
+
+- type: loadout
+  id: BlueshieldOfficerInnerBlueshieldSuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitBlueshieldOfficer
 
 - type: loadout
   id: BlueshieldOfficerInnerBlueshieldShirt

--- a/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
@@ -65,8 +65,8 @@
   id: BlueshieldOfficerJumpsuit
   name: loadout-group-bso-jumpsuit
   loadouts:
-  - BlueshieldOfficerInnerBlueshieldSkirt
   - BlueshieldOfficerInnerBlueshieldSuit
+  - BlueshieldOfficerInnerBlueshieldSkirt
   - BlueshieldOfficerInnerBlueshieldShirt
 
 - type: loadoutGroup
@@ -87,7 +87,6 @@
 - type: loadoutGroup
   id: BlueshieldOfficerShoes
   name: loadout-group-bso-shoes
-  minLimit: 0
   loadouts:
   - JackBoots
   - BlackCowboyBoots

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -18,7 +18,6 @@
   weight: 20
   startingGear: BlueshieldOfficerGear
   icon: "JobIconBlueshield"
-  requireAdminNotify: true
   joinNotifyCrew: true
   supervisors: job-supervisors-ntr-centcom
   canBeAntag: false
@@ -35,13 +34,10 @@
   - CentralCommand
   - BlueshieldOfficer
   - Service
-  - Hydroponics
-  - Kitchen
   - Cargo
-  - Theatre
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant ]
+    implants: [ MindShieldImplant, BluespaceLifelineImplant ]
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
@@ -58,6 +54,5 @@
   storage:
     back:
     - Flash
-    - BluespaceLifelineImplanter
     - SecHypo
     - BlueshieldUndetermined


### PR DESCRIPTION
revolver desc and contents in toolbox now match the rework
bso armor matches captains carapace, also fixed the abscense of a dot.
bso no longer has botany, kitchen and theater access, there's no way any head is getting hurt there, do not validhunt.
bso locker no longer has spare armor vest, you have one roundstart anyway. i kept the helmet so bso can have more armor in case or warops and such if they want to run beret on calm rounds.
locker now has security belt though, because imaging picking chester + revolver to have no way to disable IPCs other than beanbags.
bso comes preimplanted with lifeline. your equipment is extremely good now, you're not getting another chance if you fuck up,  be more responsible.

also update your PR description to include this + revolver please