### PR TITLE
further work

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -485,6 +485,8 @@
         - CombatKnife
         - Truncheon
         - BolaEnergy # Goobstation
+        - EnergySpeedloader # Goobstation
+        #- HandheldCrewMonitor # Goobstation # uncomment after #1940 is merged. or TODO: make distinct belt/webbing for BSO
       components:
         - Stunbaton
         - FlashOnTrigger

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -156,20 +156,3 @@
       sprite: Clothing/Ears/Headsets/freelance.rsi
     - type: Clothing
       sprite: Clothing/Ears/Headsets/freelance.rsi
-
-# Goobstation start
-- type: entity
-  parent: [ClothingHeadsetAlt, BaseSecurityContraband]
-  id: ClothingHeadsetAltSecurityRegular
-  name: security over-ear headset
-  components:
-  - type: ContainerFill
-    containers:
-      key_slots:
-      - EncryptionKeySecurity
-      - EncryptionKeyCommon
-  - type: Sprite
-    sprite: Clothing/Ears/Headsets/security.rsi
-  - type: Clothing
-    sprite: Clothing/Ears/Headsets/security.rsi
-# Goobstation end

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Items/firstaidkit.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Items/firstaidkit.yml
@@ -14,28 +14,15 @@
     state: purplekit
 
 - type: entity
-  id: MedkitBSOFilled
-  suffix: Filled, Medical
-  description: Contains advanced topicals and some auto injectors.
+  id: MedkitBSOFilledIPC
+  suffix: Filled
+  name: silicon repairing kit
+  description: A medkit containing the basic tools to repair silicons.
   parent: MedkitBSO
   components:
   - type: StorageFill
     contents:
-    - id: MedicatedSuture
-    - id: RegenerativeMesh
-    - id: Bloodpack
-    - id: BruteAutoInjector
-    - id: BurnAutoInjector
-
-- type: entity
-  id: MedkitBSOFilledSurgical
-  suffix: Filled, Surgical
-  description: Contains the basic tools needed for most surgeries.
-  parent: MedkitBSO
-  components:
-  - type: StorageFill
-    contents:
-    - id: ScalpelLaser
-    - id: Retractor
-    - id: Hemostat
-    - id: Cautery
+    - id: ClothingEyesGlassesMeson
+    - id: WelderIndustrial
+    - id: CableApcStack
+    - id: PowerCellHigh

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
@@ -29,9 +29,12 @@
     children:
     - id: ClothingHeadHelmetSwat
     - id: Flash
-    - id: FlashlightSeclite
-    - id: ClothingBeltSecurityFilled
+    - id: DefibrillatorCompact
+    - id: MedkitCombatFilled
+    - id: MedkitBSOFilledIPC
     - id: ClothingOuterHardsuitBlueshield
+    - id: ClothingBackpackDuffelSurgeryFilled
+    - id: FlippoLighterBlueshield
     - id: BoxZiptie
     - id: OxygenTankFilled
     - id: NitrogenTankFilled

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets_alt.yml
@@ -51,3 +51,35 @@
     sprite: _Goobstation/Clothing/Ears/Headsets/deathsquad.rsi
   - type: Clothing
     sprite: _Goobstation/Clothing/Ears/Headsets/deathsquad.rsi
+
+- type: entity
+  parent: [ClothingHeadsetAlt, BaseSecurityContraband]
+  id: ClothingHeadsetAltSecurityRegular
+  name: security over-ear headset
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeySecurity
+      - EncryptionKeyCommon
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/security.rsi
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/security.rsi
+
+- type: entity
+  parent: [ClothingHeadsetAlt, BaseCentCommcontraband]
+  id: ClothingHeadsetAltWarden
+  name: blueshield officer's over-ear headset
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommand
+      - EncryptionKeyCentCom
+      - EncryptionKeySecurity
+      - EncryptionKeyCommon
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/command.rsi # TODO: change this
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/command.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets_alt.yml
@@ -68,7 +68,7 @@
     sprite: Clothing/Ears/Headsets/security.rsi
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseCentCommcontraband]
+  parent: [ClothingHeadsetAlt, BaseCentcommContraband]
   id: ClothingHeadsetAltBlueshield
   name: blueshield officer's over-ear headset
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets_alt.yml
@@ -69,7 +69,7 @@
 
 - type: entity
   parent: [ClothingHeadsetAlt, BaseCentCommcontraband]
-  id: ClothingHeadsetAltWarden
+  id: ClothingHeadsetAltBlueshield
   name: blueshield officer's over-ear headset
   components:
   - type: ContainerFill

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -50,7 +50,7 @@
 #bso hardsuit
 
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
+  parent: [ClothingOuterHardsuitBase, BaseCentcommContraband]
   id: ClothingOuterHardsuitBlueshield
   name: blueshield hardsuit
   description: A hardsuit for the captains personal bodyguard.
@@ -60,22 +60,22 @@
   - type: Clothing
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/bso.rsi
   - type: PressureProtection
-    highPressureMultiplier: 0.5
+    highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.4
+    damageCoefficient: 0.65
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Radiation: 0.5
-        Caustic: 0.6
+        Blunt: 0.65
+        Slash: 0.65
+        Piercing: 0.6
         Heat: 0.6
+        Radiation: 0.55
+        Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.8
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change
     clothingPrototypes:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
@@ -1,7 +1,20 @@
+- type: entity
+  parent: AmmoProviderShotgunShell
+  id: BaseMagazineBoxShotgunHighCaliber
+  abstract: true
+  components:
+  - type: BallisticAmmoProvider
+    proto: null
+    whitelist:
+      tags:
+      - ShellShotgunHeavy
+  - type: Item
+    size: Small
+
 # Carpshot
 - type: entity
   name: shell box (.75 carpshot)
-  parent: AmmoProviderShotgunShell
+  parent: BaseMagazineBoxShotgunHighCaliber
   id: MagazineBoxShotgunHighCaliber
   components:
   - type: BallisticAmmoProvider
@@ -17,7 +30,7 @@
 # Normal Slug
 - type: entity
   name: shell box (.75 slug)
-  parent: AmmoProviderShotgunShell
+  parent: BaseMagazineBoxShotgunHighCaliber
   id: MagazineBoxShotgunSlugHighCaliber
   components:
   - type: BallisticAmmoProvider
@@ -37,7 +50,7 @@
 # Incendiary
 - type: entity
   name: shell box (.75 incendiary)
-  parent: AmmoProviderShotgunShell
+  parent: BaseMagazineBoxShotgunHighCaliber
   id: MagazineBoxShotgunIncendiaryHighCaliber
   components:
   - type: BallisticAmmoProvider
@@ -53,7 +66,7 @@
 # Uranium
 - type: entity
   name: shell box (.75 uranium)
-  parent: AmmoProviderShotgunShell
+  parent: BaseMagazineBoxShotgunHighCaliber
   id: MagazineBoxShotgunUraniumHighCaliber
   components:
   - type: BallisticAmmoProvider
@@ -73,7 +86,7 @@
 # Beanbag
 
 - type: entity
-  parent: AmmoProviderShotgunShell
+  parent: BaseMagazineBoxShotgunHighCaliber
   id: MagazineBoxShotgunBeanbagHighCaliber
   name: shell box (.75 beanbag)
   components:
@@ -91,7 +104,7 @@
 
 - type: entity
   name: shell box (.75 practice)
-  parent: AmmoProviderShotgunShell
+  parent: BaseMagazineBoxShotgunHighCaliber
   id: MagazineBoxShotgunPracticeHighCaliber
   components:
   - type: BallisticAmmoProvider
@@ -108,7 +121,7 @@
 # Ensnaring
 - type: entity
   id: MagazineBoxShotgunHighCaliberEnsnaring
-  parent: AmmoProviderShotgunShell
+  parent: BaseMagazineBoxShotgunHighCaliber
   name: shell box (.75 slug ensnaring)
   components:
   - type: BallisticAmmoProvider
@@ -125,7 +138,7 @@
 # EMP
 - type: entity
   id: MagazineBoxShotgunHighCaliberEMP
-  parent: AmmoProviderShotgunShell
+  parent: BaseMagazineBoxShotgunHighCaliber
   name: shell box (.75 slug EMP)
   components:
   - type: BallisticAmmoProvider
@@ -142,7 +155,7 @@
 # Flash
 - type: entity
   id: MagazineBoxShotgunHighCaliberFlash
-  parent: AmmoProviderShotgunShell
+  parent: BaseMagazineBoxShotgunHighCaliber
   name: shell box (.75 slug flash)
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
@@ -20,6 +20,7 @@
   - BlueshieldOfficerBackpack
   - BlueshieldOfficerOuter
   - BlueshieldOfficerNeck
+  - SecurityBelt
   - BlueshieldOfficerMask
   - BlueshieldOfficerShoes
   - Trinkets

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -51,7 +51,6 @@
     gloves: ClothingHandsGlovesCombat
     id: BlueshieldPDA
     ears: ClothingHeadsetAltBlueshield
-    belt: ClothingBeltSecurityFilled
     pocket1: UniqueBlueshieldOfficerLockerTeleporter
   storage:
     back:

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -35,7 +35,7 @@
   - CentralCommand
   - BlueshieldOfficer
   - Service
-  - Hydroponics # Okay, we're keeping this because I've lost three captains to ratkings in botany.
+  - Hydroponics
   - Cargo
   special:
   - !type:AddImplantSpecial
@@ -50,13 +50,12 @@
     eyes: ClothingEyesGlassesBSO
     gloves: ClothingHandsGlovesCombat
     id: BlueshieldPDA
-    ears: ClothingHeadsetAltCommand
+    ears: ClothingHeadsetAltBlueshield
+    belt: ClothingBeltSecurityFilled
     pocket1: UniqueBlueshieldOfficerLockerTeleporter
-    pocket2: PinpointerUniversal # Track any of the heads, not just the captain.
   storage:
     back:
-    - ClothingMaskGasSecurity 
+    - ClothingMaskGasSecurity
     - Flash
-    - FlippoLighterBlueshield
+    - HandheldCrewMonitor
     - BlueshieldUndetermined
-    - MedkitBSOFilled


### PR DESCRIPTION
secbelt now can hold energy speedloaders, qol

bso now has unique headset with centcomm, command, sec and common keys as bso does not need to spy on other departments as the captain (also moved sec headset to goob namespace bc why tf was it not there), requires spriting

bso can now take secbelt in loadout instead of getting it from the locker

they do not spawn with a medkit anymore, instead they get combat medkit and new ipc repairing kit in their locker

they also have handheld crew monitor now (needs #1940 to make sense) and compact defib in their locker

fixed chester ammo being not puttable back into a box, also made boxes 2x1 instead of 2x2, they took too much space

changed hardsuit stats to match syndie stealth suit, they should be more mobile but more vulnarable, though not to same degree as cmo and paramed